### PR TITLE
Add authentication check to loan request routes

### DIFF
--- a/@types/express/index.d.ts
+++ b/@types/express/index.d.ts
@@ -1,0 +1,5 @@
+declare namespace Express {
+  export interface Request {
+    userId: number;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "scripts": {
-        "lint": "eslint \"*/**/*.{js,ts}\" --quiet --fix",
+        "lint": "eslint \"*/**/*.{js,ts}\" --quiet --ignore-path .gitignore",
         "test": "echo tests passed",
         "build": "tsc",
         "start:dev": "nodemon --exec \"ts-node -r dotenv/config\" src/index.ts",
@@ -15,6 +15,7 @@
         "@types/node": "^14.11.8",
         "@typescript-eslint/eslint-plugin": "^4.4.1",
         "@typescript-eslint/parser": "^4.4.1",
+        "@types/jsonwebtoken": "^8.5.0",
         "db-migrate": "^0.11.11",
         "db-migrate-pg": "^1.2.2",
         "dotenv": "^8.2.0",

--- a/src/authentication/middleware/verifyAuthentication.ts
+++ b/src/authentication/middleware/verifyAuthentication.ts
@@ -1,0 +1,17 @@
+import { RequestHandler } from 'express';
+
+import Token from '../../utilities/Token';
+
+const verifyAuthentication: RequestHandler = (req, res, next) => {
+  const [authType, authCredentials] = req.headers.authorization?.split(' ') || ['', ''];
+  const userId = Token.validate(authCredentials);
+
+  if (authType === 'Bearer' && userId) {
+    req.userId = userId;
+    next();
+  } else {
+    res.sendStatus(401);
+  }
+};
+
+export default verifyAuthentication;

--- a/src/authentication/routeHandlers/index.ts
+++ b/src/authentication/routeHandlers/index.ts
@@ -1,0 +1,1 @@
+export { default as postAuthenticatedUser } from './postAuthenticatedUser';

--- a/src/authentication/routeHandlers/postAuthenticatedUser.ts
+++ b/src/authentication/routeHandlers/postAuthenticatedUser.ts
@@ -1,8 +1,7 @@
 import { RequestHandler } from 'express';
 
-import Token from '../../utilities/Token';
-
 import authenticateUser from '../../db/users/authenticateUser';
+import Token from '../../utilities/Token';
 
 const postAuthenticatedUser: RequestHandler = async (req, res) => {
   const { email, password } = req.body;
@@ -12,8 +11,10 @@ const postAuthenticatedUser: RequestHandler = async (req, res) => {
   if (userAuth) {
     const token = Token.generate(userAuth);
 
-    return res.json({ token });
+    res.json({ token });
   } else {
-    return res.sendStatus(401);
+    res.sendStatus(401);
   }
 };
+
+export default postAuthenticatedUser;

--- a/src/authentication/routes.ts
+++ b/src/authentication/routes.ts
@@ -1,7 +1,11 @@
-import { Router, json } from 'express';
+import { json, Router } from 'express';
+
+import { postAuthenticatedUser } from './routeHandlers';
 
 const routes = Router();
 
 routes.use(json());
 
-routes.get('/');
+routes.post('/', postAuthenticatedUser);
+
+export default routes;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,9 +1,17 @@
 import { Router } from 'express';
 
+import verifyAuthentication from './authentication/middleware/verifyAuthentication';
+import authenticateRoutes from './authentication/routes';
 import loanRequestRoutes from './loanRequests/routes';
 
+const authenticatedRoutes = Router();
 const routes = Router();
 
-routes.use('/loan_requests', loanRequestRoutes);
+routes.use('/authenticate', authenticateRoutes);
+
+authenticatedRoutes.use(verifyAuthentication);
+authenticatedRoutes.use('/loan_requests', loanRequestRoutes);
+
+routes.use(authenticatedRoutes);
 
 export default routes;

--- a/src/utilities/Token.ts
+++ b/src/utilities/Token.ts
@@ -1,12 +1,24 @@
+import { sign, verify } from 'jsonwebtoken';
+
 import User from '../types/User';
 
-import { sign } from 'jsonwebtoken';
-
-import { validate } from 'jsonwebtoken';
-
 const Token = {
-  generate: (userId: User['id']) => {
-    return sign({ id: userId }, process.env.TOKEN_SECRET || '');
+  generate: (userId: User['id']): string => {
+    return sign({ id: userId }, process.env.TOKEN_SECRET || 'secretTime');
+  },
+
+  validate: (token: string): User['id'] | null => {
+    try {
+      const payload = verify(token, process.env.TOKEN_SECRET || 'secretTime');
+
+      if (typeof payload === 'string') {
+        return null;
+      }
+
+      return (payload as { id: User['id'] }).id;
+    } catch {
+      return null;
+    }
   },
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -45,7 +45,7 @@
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    "typeRoots": ["./@types"],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -111,6 +111,13 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
 
+"@types/jsonwebtoken@^8.5.0":
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-8.5.0.tgz#2531d5e300803aa63279b232c014acf780c981c5"
+  integrity sha512-9bVao7LvyorRGZCw0VmH/dr7Og+NdjYSsKAxB43OQoComFbBgsEpoR9JW6+qSq/ogwVBg8GI2MfAlk4SYI4OLg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/mime@*":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.3.tgz#c893b73721db73699943bfc3653b1deb7faa4a3a"


### PR DESCRIPTION
This adds in some extra logic to tie together the authentication logic and also adds an authentication check to the existing `/loan_requests` endpoint.